### PR TITLE
set overprovision to false for vmss

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -228,6 +228,7 @@ resource "azurerm_virtual_machine_scale_set" "test" {
   location            = "${azurerm_resource_group.test.location}"
   resource_group_name = "${azurerm_resource_group.test.name}"
   upgrade_policy_mode = "Automatic"
+  overprovision       = false
 
   sku {
     name     = "Standard_D1_v2"


### PR DESCRIPTION
By default, vmss will over provision.  This will mis-align Service Fabric upgrade domain as more nodes will be created and later gets deleted.